### PR TITLE
Check for going past the end of the string

### DIFF
--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -299,7 +299,10 @@
         if(!$terminate && !$escape)
         {
           $text .= $this->char;
-          $this->GetChar();
+
+          //check that we aren't going to go past the end of the string.
+          if($this->pos+1 < $this->len)
+            $this->GetChar();
         }
       }
       while(!$terminate && $this->pos < $this->len);


### PR DESCRIPTION
If the RTF is not well formed, it is possible (and has for me) to go
past the end of the string at this point because this can be the second
“GetChar()” called after checking for the length of the string.