### PR TITLE
Add convert script

### DIFF
--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -481,4 +481,17 @@
       $this->EndState();
     }
   }
-?>
+
+  if (__FILE__ === realpath($_SERVER['SCRIPT_NAME']) && php_sapi_name() === 'cli') {
+    if (isset($_SERVER['argv'][1]) && ($_SERVER['argv'][1] !== '-')) {
+      $file = $_SERVER['argv'][1];
+    } else {
+      $file = 'php://stdin';
+    }
+
+    $reader = new RtfReader();
+    $rtf = file_get_contents($file);
+    $reader->Parse($rtf);
+    $formatter = new RtfHtml();
+    echo $formatter->Format($reader->root);
+  }


### PR DESCRIPTION
- When this script is run directly, and then convert to HTML.
- `?>` is unnecessary.

## usage

```
% cat ~/target.rtf | php ./rtf-html-php.php > export.html
% php ./rtf-html-php.php ~/target.rtf | w3m -T text/html
```