### PR TITLE
Added error handling in case of truncated RTF

### DIFF
--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -137,7 +137,12 @@
  
     protected function GetChar()
     {
-      $this->char = $this->rtf[$this->pos++];
+      $this->char = null;
+      if ($this->pos < strlen($this->rtf)) {
+        $this->char = $this->rtf[$this->pos++];
+      } else {
+        $this->err = "Tried to read past EOF, RTF is probably truncated";
+      }
     }
  
     protected function ParseStartGroup()


### PR DESCRIPTION
This fix avoids a PHP Notice when the parser tries to read past RTF's EOF, which normally happens when the parsed RTF is truncated. Adds an 'err' object attribute, the client can verify whether this attribute exists, and use the message to log the error and/or reject the RTF.