### PR TITLE
Fixing Remaining Unicode conversion problem

### DIFF
--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -285,8 +285,7 @@
       do
       {
         $terminate = false;
-        $escape = false;
- 
+         
         // Is this an escape?
         if($this->char == '\\')
         {
@@ -295,9 +294,10 @@
           $this->GetChar();
           switch($this->char)
           {
-            case '\\': $text .= '\\'; break;
-            case '{':  $text .= '{';  break;
-            case '}':  $text .= '}';  break;
+            case '\\':
+            case '{':
+            case '}':
+              break;
             default:
               // Not an escape. Roll back.
               $this->pos = $this->pos - 2;
@@ -311,7 +311,7 @@
           $terminate = true;
         }
  
-        if(!$terminate && !$escape)
+        if(!$terminate)
         {
           $text .= $this->char;
           $this->GetChar();

--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -208,7 +208,10 @@
         $this->GetChar();
       }
       if($parameter === null) $parameter = 1;
- 
+      
+      // convert to a negative number when applicable
+      if($negative) $parameter = -$parameter;
+      
       // If this is \u, then the parameter will be followed by 
       // a character.
       if($word == "u") 

--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -208,7 +208,6 @@
         $this->GetChar();
       }
       if($parameter === null) $parameter = 1;
-      if($negative) $parameter = -$parameter;
  
       // If this is \u, then the parameter will be followed by 
       // a character.

--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -285,7 +285,7 @@
       do
       {
         $terminate = false;
-         
+        
         // Is this an escape?
         if($this->char == '\\')
         {
@@ -515,7 +515,7 @@
     protected function FormatControlSymbol($symbol)
     {
       if($symbol->symbol == '\'')
-        $this->ApplyStyle(htmlentities(chr($symbol->parameter), ENT_QUOTES, 'ISO-8859-1'));
+        $this->ApplyStyle("&#{$symbol->parameter};");
     }
  
     protected function FormatText($text)


### PR DESCRIPTION
Fixing issues #36 , #27 : UTF characters in form of \\'hh are not converted correctly mainly because of limiting chr() function dealing only with ASCII characters.
Regards.

Fixing Issue #35 : bug in parsing escaped characters now is fixed.
