### PR TITLE
Fixed Color Table does not ALWAYS have a : 

### DIFF
--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -437,7 +437,7 @@
       $colortbl = array(0 => null); 
       $c = count($colorTblGrp);
       $color = '';
-      for ($i=2; $i<$c; $i++) { // iterate through colors
+      for ($i=1; $i<$c; $i++) { // iterate through colors
         if ($colorTblGrp[$i] instanceof RtfControlWord) {
           // extract RGB color and convert it to hex string
           $color = sprintf('#%02x%02x%02x', // hex string format


### PR DESCRIPTION
The colortbl does not always have a : separating the values and the keyword. I have changed the starting index to 1 so it can check if the : is present. If it is it skips it and continues as normal