### PR TITLE
Initialize $output to ''

### DIFF
--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -620,6 +620,8 @@
  
   class RtfHtml
   {
+    private $output = '';
+
     // Initialise Encoding
     public function __construct($encoding = 'HTML-ENTITIES')
     {


### PR DESCRIPTION
The code appends to the output variable without initializing it, so it throws an exception:
```
ErrorException: Undefined property: RtfHtml::$output
```