### PR TITLE
Fix bug with formatter removing last 3 chars in document

### DIFF
--- a/rtf-html-php.php
+++ b/rtf-html-php.php
@@ -656,8 +656,11 @@
       $this->OpenTag('p');
       // Begin format
       $this->ProcessGroup($root);
-      // Remove the last opened <p> tag and return
-      return substr($this->output ,0, -3);
+      if (substr($this->output, -3) == "<p>") {
+        // If the last 3 chars open a new <p> tag, remove it
+        $this->output = substr($this->output, 0, -3);
+      }
+      return $this->output;
     }
     
      protected function ExtractFontTable($fontTblGrp)


### PR DESCRIPTION
# What does this PR do?
This PR fixes a bug where rtf-to-html would sometimes cut of the last 3 characters of your document.

The code document that it will remove the `<p>` tag opened in the last characters of the (then already generated) html. The formatting however does not always create this `<p>` tag in the end. Some documents don't 'define' paragraphs at all (people use `shift+enter` so there are only new-lines (or not even that). In those scenario's the "old" code would simply cut of the last 3 chars of the last word you ty...  (haha)

## How does this PR solve this?
By checking if the last 3 characters of the generated HTML are actually `<p>` and only then remove the last 3 chars.