### PR TITLE
Fix placing comma between font-family names.

### DIFF
--- a/src/Html/Font.php
+++ b/src/Html/Font.php
@@ -14,6 +14,6 @@ class Font
     if($this->name) array_push($list, $this->name);
     if($this->family) array_push($list, $this->family);
     if(sizeof($list) == 0) return "";
-    return "font-family:" . join($list) . ";";
+    return "font-family:" . join($list, ',') . ";";
   }
 }

--- a/tests/FontFamilyTest.php
+++ b/tests/FontFamilyTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use RtfHtmlPhp\Document;
+use RtfHtmlPhp\Html\HtmlFormatter;
+
+final class FontFamilyTestTest extends TestCase
+{
+  public function testParseFontFamilyHtml(): void
+  {
+    $rtf = file_get_contents("tests/rtf/fonts.rtf");
+    $document = new Document($rtf);
+    $formatter = new HtmlFormatter();
+    $html = $formatter->Format($document);    
+
+    $this->assertEquals(
+      '<p><span style="font-family:Arial,sans-serif;font-size:15px;">Hello, world.</span></p>',
+      $html
+    );
+  }  
+}

--- a/tests/rtf/fonts.rtf
+++ b/tests/rtf/fonts.rtf
@@ -1,0 +1,4 @@
+{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fswiss\fcharset0 Arial;}}
+{\*\generator Riched20 10.0.18362}\viewkind4\uc1 
+\pard\sa200\sl276\slmult1\fs22\lang9 Hello, world.\par
+}


### PR DESCRIPTION
Fonts which have both both a family and name configured result in bad CSS syntax, as the name and family are concatenated with no delimiter.

For example: `\fonttbl{\f0\fswiss\fcharset0 Arial;}` should render as `font-family:Arial,sans-serif;` not `font-family:Arialsans-serif;` as it was previously.

Fixed and added a unit test.