### PR TITLE
add ext-mbstring to required-section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
       "phpunit tests"
     ]
   },
-  "require": {},
+  "require": {
+    "ext-mbstring": "*"
+  },
   "autoload": {
     "psr-4": {
       "RtfHtmlPhp\\": "src/"


### PR DESCRIPTION
By adding ext-mbstring to the required section, composer will check if mb_string extension is loaded.