### PR TITLE
Clear previous output when formatting

### DIFF
--- a/src/Html/HtmlFormatter.php
+++ b/src/Html/HtmlFormatter.php
@@ -31,6 +31,8 @@ class HtmlFormatter
   
   public function Format(Document $document)
   {
+    // Clear current output
+    $this->output = '';
     // Keep track of style modifications
     $this->previousState = null;
     // and create a stack of states


### PR DESCRIPTION
When formatting multiple documents in a loop, the output of the HtmlFormatter is never reset so each document is appended to the previous ones.
The workaround is to create a new instance of the formatter for each document, but goes against using the library with dependency injection based frameworks.
(I use it with Symfony a like to let the framework create instances of the formatter when needed)