### PR TITLE
rtf formatter crash on "exotic" fonts

### DIFF
--- a/src/Html/State.php
+++ b/src/Html/State.php
@@ -63,7 +63,7 @@ class State
     // if($this->state->end_underline) {$span .= "text-decoration:none;";}
     if($this->strike) $style .= "text-decoration:line-through;";
     if($this->hidden) $style .= "display:none;";
-    if(isset($this->font)) {
+    if(isset($this->font) && count( self::$fonttbl)>0) {
       $font = self::$fonttbl[$this->font];
       $style .= $font->toStyle();
     }


### PR DESCRIPTION
There was a crash on this line, in the file State.php:

`$font = self::$fonttbl[$this->font];`

To trace the problem, we can go into LoadFont and ExtractFontTable in HtmlFormatter.php. Somehow the way rtf is setting the non-common font is not included in this formatter.
To avoid the crash, I changed this:

```
    if(isset($this->font) {
      $font = self::$fonttbl[$this->font];
      $style .= $font->toStyle();
    }
```

to
```

    if(isset($this->font) && count( self::$fonttbl)>0) {
      $font = self::$fonttbl[$this->font];
      $style .= $font->toStyle();
    }
```

The result is the document without the "exotic" font.
